### PR TITLE
Specify en-US environment

### DIFF
--- a/test.py
+++ b/test.py
@@ -26,6 +26,7 @@ if __name__ == '__main__':
         "-disable-features=FlashDeprecationWarning,EnablePasswordsAccountStorage",
         "-deny-permission-prompts",
         "-disable-gpu",
+        "-accept-lang=en-US",
     ]
 
     for argument in arguments:


### PR DESCRIPTION
Cannot click automatically in a non-en-US environment, So you need to specify accept-lang as en-US
