### PR TITLE
linux headless

### DIFF
--- a/server.py
+++ b/server.py
@@ -31,6 +31,7 @@ app = FastAPI()
 # Pydantic model for the response
 class CookieResponse(BaseModel):
     cookies: Dict[str, str]
+    user_agent: str
 
 # Function to check if the URL is safe
 def is_safe_url(url: str) -> bool:
@@ -64,8 +65,9 @@ async def get_cookies(url: str, retries: int = 5):
     try:
         driver = bypass_cloudflare(url, retries, log)
         cookies = driver.cookies(as_dict=True)
+        user_agent = driver.user_agent
         driver.quit()
-        return CookieResponse(cookies=cookies)
+        return CookieResponse(cookies=cookies, user_agent=user_agent)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -81,6 +83,7 @@ async def get_html(url: str, retries: int = 5):
 
         response = Response(content=html, media_type="text/html")
         response.headers['cookies'] = cookies_json
+        response.headers['user_agent'] = driver.user_agent
         driver.quit()
         return response
     except Exception as e:

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 pydantic
 uvicorn
+PyVirtualDisplay


### PR DESCRIPTION
cloudflare will not bypass with DrissionPage headless mode. That's why it's using a virtual display. 


--headless will work on any x11 system that has xfvb installed
it doesn't work on macOS right now.it should work with xquarts, but it doesn't. It won't fail, but it will not run headless. My guess is that they have some custom display config for macOS, which bypasses xfvb. 
<img width="1212" alt="Screenshot 2024-08-12 at 18 45 40" src="https://github.com/user-attachments/assets/51cc4cc6-19ba-4c2f-8abf-ddec728bcb04">

