### PR TITLE
ci: build docker image and push it to GitHub container registry

### DIFF
--- a/.github/workflows/docker-ghcr.yaml
+++ b/.github/workflows/docker-ghcr.yaml
@@ -1,0 +1,16 @@
+name: Build and publish a Docker image to ghcr.io
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master # https://github.com/marketplace/actions/push-to-ghcr
+        with:
+          image_name: ${{ github.repository }}  # it will be lowercased internally
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Then, run the Docker container:
 docker run -p 8000:8000 cloudflare-bypass
 ```
 
+Alternatively, you can skip `docker build` step, and run the container using pre-build image:
+```bash
+docker run -p 8000:8000 ghcr.io/sarperavci/CloudflareBypassForScraping:latest
+```
 
 # What is this not?
 


### PR DESCRIPTION
this CI workflow will build and push docker image to GitHub container registry each time new commit lands on the `main` branch

closes #47